### PR TITLE
Fix update bug for HID devices on Windows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ keywords = ["cli", "touch-encoder", "te"]
 version = "0.1.0"
 
 dependencies = [
-    "hidapi==0.14.0",
+    "hidapi==0.14.0.post4",
     "can-j1939==2.0.12",
     "libusb==1.0.27",
     "rich==13.7.1",

--- a/te/interface/hid/comm_interface/hid_interface_win.py
+++ b/te/interface/hid/comm_interface/hid_interface_win.py
@@ -1,6 +1,6 @@
 import queue
 import time
-from typing import Dict, Optional, List
+from typing import Dict, Optional, List, Union
 
 import hid as hidapi
 
@@ -109,7 +109,7 @@ class HIDInterfaceWin(HIDInterface):
                 res = hid_func.read(self.MAX_REPORT_SIZE)
                 if res:
                     self._log_msg(res, prefix='recv', rpt_type=hid_func)
-                    if hid_func in [self.cmd, self.widget]:
+                    if hid_func in [self.cmd, self.widget, self._update]:
                         self._recv_queue.put(BaseReport(res, timestamp=time.time()))
 
     def recv_rpt(self, timeout=0.1) -> Optional[BaseReport]:
@@ -135,6 +135,13 @@ class HIDInterfaceWin(HIDInterface):
         report = self._sw_ver.get_feature_report(report_id, 7)
         self._log_msg(report, prefix='recv', rpt_type=self._sw_ver)
         return report
+
+    def send(self, hid_func: hidapi.device, data: Union[List[int], bytes]) -> int:
+        """
+        Extending send function due to hidapi.write() always returns 1024 upon successful send on Windows.
+        """
+        res = super().send(hid_func, data)
+        return len(data) if res == 1024 else res
 
     def send_update_payload(self, payload: bytes):
         """

--- a/te/interface/hid/comm_interface/hid_interface_win.py
+++ b/te/interface/hid/comm_interface/hid_interface_win.py
@@ -103,14 +103,18 @@ class HIDInterfaceWin(HIDInterface):
         :return:
         """
         while self._recv_thread_state != self.RecvThreadState.STOPPED:
-            for hid_func in [self.cmd, self.widget, self._rie_iface_1, self._rie_iface_2, self._update]:
-                if hid_func is None:
-                    continue
-                res = hid_func.read(self.MAX_REPORT_SIZE)
-                if res:
-                    self._log_msg(res, prefix='recv', rpt_type=hid_func)
-                    if hid_func in [self.cmd, self.widget, self._update]:
-                        self._recv_queue.put(BaseReport(res, timestamp=time.time()))
+            try:
+                for hid_func in [self.cmd, self.widget, self._rie_iface_1, self._rie_iface_2, self._update]:
+                    if hid_func is None:
+                        continue
+                    res = hid_func.read(self.MAX_REPORT_SIZE)
+                    if res:
+                        self._log_msg(res, prefix='recv', rpt_type=hid_func)
+                        if hid_func in [self.cmd, self.widget, self._update]:
+                            self._recv_queue.put(BaseReport(res, timestamp=time.time()))
+            except OSError:
+                self.logger.error('Device disconnected')
+                break
 
     def recv_rpt(self, timeout=0.1) -> Optional[BaseReport]:
         """


### PR DESCRIPTION
This PR addresses the following:

* HID send command always return fixed number of amount of data sent which was causing update to fail. Extended the send function for Windows to return proper number for data sent.
* Wrap recv loop in try/catch to prevent error messages in the CLI.